### PR TITLE
BDL-1262: fix kiwibank enum wire value

### DIFF
--- a/src/BlinkDebitApiClient.Test/Model/V1/BankTests.cs
+++ b/src/BlinkDebitApiClient.Test/Model/V1/BankTests.cs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 BlinkPay
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+using BlinkDebitApiClient.Model.V1;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace BlinkDebitApiClient.Test.Model.V1;
+
+/// <summary>
+/// Unit tests for <see cref="Bank"/> enum wire (JSON) serialisation.
+/// The enum is annotated with <c>StringEnumConverter</c>, so the <c>EnumMember</c>
+/// value is the on-the-wire representation for both requests and responses.
+/// </summary>
+public class BankTests
+{
+    [Theory(DisplayName = "Each Bank enum member serialises to its expected wire value")]
+    [InlineData(Bank.ASB, "ASB")]
+    [InlineData(Bank.ANZ, "ANZ")]
+    [InlineData(Bank.BNZ, "BNZ")]
+    [InlineData(Bank.Westpac, "Westpac")]
+    [InlineData(Bank.KiwiBank, "Kiwibank")]
+    [InlineData(Bank.PNZ, "PNZ")]
+    [InlineData(Bank.Cybersource, "Cybersource")]
+    public void SerialisesToExpectedWireValue(Bank bank, string expectedWireValue)
+    {
+        var json = JsonConvert.SerializeObject(bank);
+
+        Assert.Equal($"\"{expectedWireValue}\"", json);
+    }
+
+    [Theory(DisplayName = "Each expected wire value deserialises to its Bank enum member")]
+    [InlineData("ASB", Bank.ASB)]
+    [InlineData("ANZ", Bank.ANZ)]
+    [InlineData("BNZ", Bank.BNZ)]
+    [InlineData("Westpac", Bank.Westpac)]
+    [InlineData("Kiwibank", Bank.KiwiBank)]
+    [InlineData("PNZ", Bank.PNZ)]
+    [InlineData("Cybersource", Bank.Cybersource)]
+    public void DeserialisesFromExpectedWireValue(string wireValue, Bank expectedBank)
+    {
+        var bank = JsonConvert.DeserializeObject<Bank>($"\"{wireValue}\"");
+
+        Assert.Equal(expectedBank, bank);
+    }
+}

--- a/src/BlinkDebitApiClient/BlinkDebitApiClient.csproj
+++ b/src/BlinkDebitApiClient/BlinkDebitApiClient.csproj
@@ -12,7 +12,7 @@
     <Description>Blink Debit API Client for .NET 8</Description>
     <Copyright>Copyright (c) 2023 BlinkPay</Copyright>
     <RootNamespace>BlinkDebitApiClient</RootNamespace>
-    <Version>1.3.0-SNAPSHOT</Version>
+    <Version>1.4.1</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\BlinkDebitApiClient.xml</DocumentationFile>
     <RepositoryUrl>https://github.com/BlinkPay/Blink-Debit-API-Client-DotNet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/BlinkDebitApiClient/Model/V1/Bank.cs
+++ b/src/BlinkDebitApiClient/Model/V1/Bank.cs
@@ -54,9 +54,9 @@ public enum Bank
     [EnumMember(Value = "Westpac")] Westpac = 4,
 
     /// <summary>
-    /// Enum KiwiBank for value: KiwiBank
+    /// Enum KiwiBank for value: Kiwibank
     /// </summary>
-    [EnumMember(Value = "KiwiBank")] KiwiBank = 5,
+    [EnumMember(Value = "Kiwibank")] KiwiBank = 5,
 
     /// <summary>
     /// Enum PNZ for value: PNZ


### PR DESCRIPTION
Change the Bank.KiwiBank EnumMember wire value from "KiwiBank" to "Kiwibank" to match the API contract. The C# identifier and numeric value are kept unchanged, so this is source-compatible.

Add round-trip serialisation tests covering every Bank enum member.